### PR TITLE
Bug in incrBy/decrBy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+phpredis (2.0.8-2) unstable; urgency=low
+
+  * Fixed problem when doing incrBy or decrBy with 1 like incrBy('key', 1).
+
+ -- Simon Effenberg <se@plista.com>  Wed, 27 Oct 2010 13:33:18 +0200
+
 phpredis (2.0.8-1) unstable; urgency=low
 
   * Merged with upstream but there seems to be no new version.

--- a/redis.c
+++ b/redis.c
@@ -737,6 +737,7 @@ PHP_METHOD(Redis, incr){
                                      &key, &key_len, &val) == FAILURE) {
         RETURN_FALSE;
     }
+
     if(val == 1) {
         redis_atomic_increment(INTERNAL_FUNCTION_PARAM_PASSTHRU, "INCR", 1);
     } else {
@@ -760,7 +761,12 @@ PHP_METHOD(Redis, incrBy){
                                      &key, &key_len, &val) == FAILURE) {
         RETURN_FALSE;
     }
-    redis_atomic_increment(INTERNAL_FUNCTION_PARAM_PASSTHRU, "INCRBY", val);
+
+    if(val == 1) {
+        redis_atomic_increment(INTERNAL_FUNCTION_PARAM_PASSTHRU, "INCR", 1);
+    } else {
+        redis_atomic_increment(INTERNAL_FUNCTION_PARAM_PASSTHRU, "INCRBY", val);
+    }
 }
 /* }}} */
 
@@ -779,6 +785,7 @@ PHP_METHOD(Redis, decr)
                                      &key, &key_len, &val) == FAILURE) {
         RETURN_FALSE;
     }
+
     if(val == 1) {
         redis_atomic_increment(INTERNAL_FUNCTION_PARAM_PASSTHRU, "DECR", 1);
     } else {
@@ -802,7 +809,12 @@ PHP_METHOD(Redis, decrBy){
                                      &key, &key_len, &val) == FAILURE) {
         RETURN_FALSE;
     }
-    redis_atomic_increment(INTERNAL_FUNCTION_PARAM_PASSTHRU, "DECRBY", val);
+
+    if(val == 1) {
+        redis_atomic_increment(INTERNAL_FUNCTION_PARAM_PASSTHRU, "DECR", 1);
+    } else {
+        redis_atomic_increment(INTERNAL_FUNCTION_PARAM_PASSTHRU, "DECRBY", val);
+    }
 }
 /* }}} */
 


### PR DESCRIPTION
Because of checking if value is == 1 in the redis_atomic_increment method there was this situation if you incrBy/decrBy 1

the redis server gots the command "INCRBY"/"DECRBY" without the 1 so this failed.
