### PR TITLE
Little bugfix for the timeout parameter.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+phpredis (2.0.10-1) unstable; urgency=low
+
+  * Fixed wrong timeout option when setting timeout to lower then 1s.
+
+ -- Simon Effenberg <se@plista.com>  Mon, 08 Nov 2010 12:30:54 +0100
+
 phpredis (2.0.10) unstable; urgency=low
 
   * Merged with upstream

--- a/library.c
+++ b/library.c
@@ -706,11 +706,11 @@ PHPAPI int redis_sock_connect(RedisSock *redis_sock TSRMLS_DC)
     }
 
     tv.tv_sec  = (time_t)redis_sock->timeout;
-    tv.tv_usec = ((int)(redis_sock->timeout - tv.tv_sec)) * 1000000;
+    tv.tv_usec = (int)((redis_sock->timeout - tv.tv_sec) * 1000000);
 
     host_len = spprintf(&host, 0, "%s:%d", redis_sock->host, redis_sock->port);
 
-    if(tv.tv_sec != 0) {
+    if(tv.tv_sec != 0 || tv.tv_usec != 0) {
         tv_ptr = &tv;
     }
     redis_sock->stream = php_stream_xport_create(host, host_len, ENFORCE_SAFE_MODE,


### PR DESCRIPTION
There was a problem for the microtime part (casting to int before multiple with 10000... so that each microtime part first was set to 0) and when using a timeout lower then 1s (besides the one with the casting also it never setted the timeout value if the seconds part was 0).
