### PR TITLE
Fixing missing declaration warnings

### DIFF
--- a/library.c
+++ b/library.c
@@ -1,5 +1,8 @@
+#include "php_redis.h"
+#include "library.h"
 #include "common.h"
 #include "php_network.h"
+#include "zend_exceptions.h"
 #include <sys/types.h>
 #include <netinet/tcp.h>  /* TCP_NODELAY */
 #include <sys/socket.h>

--- a/library.h
+++ b/library.h
@@ -2,6 +2,7 @@ void add_constant_long(zend_class_entry *ce, char *name, int value);
 int integer_length(int i);
 int double_length(double d, int *has_F);
 int redis_cmd_format(char **ret, char *format, ...);
+int redis_cmd_format_static(char **ret, char *keyword, char *format, ...);
 
 PHPAPI char * redis_sock_read(RedisSock *redis_sock, int *buf_len TSRMLS_DC);
 


### PR DESCRIPTION
This patch fixes warnings about missing declarations when compiling with -Wall.
