### PR TITLE
Fixed segfault and ZTS build

### DIFF
--- a/library.c
+++ b/library.c
@@ -173,16 +173,6 @@ PHPAPI char *redis_sock_read(RedisSock *redis_sock, int *buf_len TSRMLS_DC)
     return NULL;
 }
 
-void add_constant_long(zend_class_entry *ce, char *name, int value) {
-
-    zval *constval;
-    constval = pemalloc(sizeof(zval), 1);
-    INIT_PZVAL(constval);
-    ZVAL_LONG(constval, value);
-    zend_hash_add(&ce->constants_table, name, 1 + strlen(name),
-        (void*)&constval, sizeof(zval*), NULL);
-}
-
 int
 integer_length(int i) {
     int sz = 0;

--- a/library.c
+++ b/library.c
@@ -1081,7 +1081,7 @@ PHPAPI void redis_free_socket(RedisSock *redis_sock)
 }
 
 PHPAPI int
-redis_serialize(RedisSock *redis_sock, zval *z, char **val, int *val_len TSRMLS_CC) {
+redis_serialize(RedisSock *redis_sock, zval *z, char **val, int *val_len TSRMLS_DC) {
 #if ZEND_MODULE_API_NO >= 20100000
 	php_serialize_data_t ht;
 #else
@@ -1153,7 +1153,7 @@ redis_serialize(RedisSock *redis_sock, zval *z, char **val, int *val_len TSRMLS_
 }
 
 PHPAPI int
-redis_unserialize(RedisSock *redis_sock, const char *val, int val_len, zval **return_value TSRMLS_CC) {
+redis_unserialize(RedisSock *redis_sock, const char *val, int val_len, zval **return_value TSRMLS_DC) {
 
 	php_unserialize_data_t var_hash;
 	int ret;
@@ -1193,7 +1193,7 @@ redis_unserialize(RedisSock *redis_sock, const char *val, int val_len, zval **re
 }
 
 PHPAPI int
-redis_key_prefix(RedisSock *redis_sock, char **key, int *key_len TSRMLS_CC) {
+redis_key_prefix(RedisSock *redis_sock, char **key, int *key_len TSRMLS_DC) {
 	if(redis_sock->prefix == NULL || redis_sock->prefix_len == 0) {
 		return 0;
 	}

--- a/library.h
+++ b/library.h
@@ -1,4 +1,3 @@
-void add_constant_long(zend_class_entry *ce, char *name, int value);
 int integer_length(int i);
 int double_length(double d);
 int redis_cmd_format(char **ret, char *format, ...);

--- a/library.h
+++ b/library.h
@@ -32,9 +32,9 @@ PHPAPI int redis_check_eof(RedisSock *redis_sock TSRMLS_DC);
 PHPAPI void redis_free_socket(RedisSock *redis_sock);
 
 PHPAPI int
-redis_serialize(RedisSock *redis_sock, zval *z, char **val, int *val_len TSRMLS_CC);
+redis_serialize(RedisSock *redis_sock, zval *z, char **val, int *val_len TSRMLS_DC);
 PHPAPI int
-redis_key_prefix(RedisSock *redis_sock, char **key, int *key_len TSRMLS_CC);
+redis_key_prefix(RedisSock *redis_sock, char **key, int *key_len TSRMLS_DC);
 
 PHPAPI int
-redis_unserialize(RedisSock *redis_sock, const char *val, int val_len, zval **return_value TSRMLS_CC);
+redis_unserialize(RedisSock *redis_sock, const char *val, int val_len, zval **return_value TSRMLS_DC);

--- a/redis.c
+++ b/redis.c
@@ -307,28 +307,29 @@ PHP_MINIT_FUNCTION(redis)
         redis_sock_name, module_number
     );
 
-	add_constant_long(redis_ce, "REDIS_NOT_FOUND", REDIS_NOT_FOUND);
-	add_constant_long(redis_ce, "REDIS_STRING", REDIS_STRING);
-	add_constant_long(redis_ce, "REDIS_SET", REDIS_SET);
-	add_constant_long(redis_ce, "REDIS_LIST", REDIS_LIST);
-	add_constant_long(redis_ce, "REDIS_ZSET", REDIS_ZSET);
-	add_constant_long(redis_ce, "REDIS_HASH", REDIS_HASH);
 
-	add_constant_long(redis_ce, "ATOMIC", ATOMIC);
-	add_constant_long(redis_ce, "MULTI", MULTI);
-	add_constant_long(redis_ce, "PIPELINE", PIPELINE);
+    zend_declare_class_constant_long(redis_ce, ZEND_STRL("REDIS_NOT_FOUND"), REDIS_NOT_FOUND TSRMLS_CC);
+    zend_declare_class_constant_long(redis_ce, ZEND_STRL("REDIS_STRING"), REDIS_STRING TSRMLS_CC);
+    zend_declare_class_constant_long(redis_ce, ZEND_STRL("REDIS_SET"), REDIS_SET TSRMLS_CC);
+    zend_declare_class_constant_long(redis_ce, ZEND_STRL("REDIS_LIST"), REDIS_LIST TSRMLS_CC);
+    zend_declare_class_constant_long(redis_ce, ZEND_STRL("REDIS_ZSET"), REDIS_ZSET TSRMLS_CC);
+    zend_declare_class_constant_long(redis_ce, ZEND_STRL("REDIS_HASH"), REDIS_HASH TSRMLS_CC);
+
+    zend_declare_class_constant_long(redis_ce, ZEND_STRL("ATOMIC"), ATOMIC TSRMLS_CC);
+    zend_declare_class_constant_long(redis_ce, ZEND_STRL("MULTI"), MULTI TSRMLS_CC);
+    zend_declare_class_constant_long(redis_ce, ZEND_STRL("PIPELINE"), PIPELINE TSRMLS_CC);
 
     /* options */
-    add_constant_long(redis_ce, "OPT_SERIALIZER", REDIS_OPT_SERIALIZER);
-    add_constant_long(redis_ce, "OPT_PREFIX", REDIS_OPT_PREFIX);
+    zend_declare_class_constant_long(redis_ce, ZEND_STRL("OPT_SERIALIZER"), REDIS_OPT_SERIALIZER TSRMLS_CC);
+    zend_declare_class_constant_long(redis_ce, ZEND_STRL("OPT_PREFIX"), REDIS_OPT_PREFIX TSRMLS_CC);
 
     /* serializer */
-    add_constant_long(redis_ce, "SERIALIZER_NONE", REDIS_SERIALIZER_NONE);
-    add_constant_long(redis_ce, "SERIALIZER_PHP", REDIS_SERIALIZER_PHP);
-    add_constant_long(redis_ce, "SERIALIZER_IGBINARY", REDIS_SERIALIZER_IGBINARY);
+    zend_declare_class_constant_long(redis_ce, ZEND_STRL("SERIALIZER_NONE"), REDIS_SERIALIZER_NONE TSRMLS_CC);
+    zend_declare_class_constant_long(redis_ce, ZEND_STRL("SERIALIZER_PHP"), REDIS_SERIALIZER_PHP TSRMLS_CC);
+    zend_declare_class_constant_long(redis_ce, ZEND_STRL("SERIALIZER_IGBINARY"), REDIS_SERIALIZER_IGBINARY TSRMLS_CC);
 
-	zend_declare_class_constant_stringl(redis_ce, "AFTER", 5, "after", 5 TSRMLS_CC);
-	zend_declare_class_constant_stringl(redis_ce, "BEFORE", 6, "before", 6 TSRMLS_CC);
+    zend_declare_class_constant_stringl(redis_ce, ZEND_STRL("AFTER"), ZEND_STRL("after") TSRMLS_CC);
+    zend_declare_class_constant_stringl(redis_ce, ZEND_STRL("BEFORE"), ZEND_STRL("before") TSRMLS_CC);
 
     /* declare session handler */
     php_session_register_module(&ps_mod_redis);

--- a/redis.c
+++ b/redis.c
@@ -460,7 +460,7 @@ PHPAPI int redis_connect(INTERNAL_FUNCTION_PARAMETERS, int persistent) {
 		return FAILURE;
 	}
 
-	id = zend_list_insert(redis_sock, le_redis_sock);
+	id = zend_list_insert(redis_sock, le_redis_sock TSRMLS_CC);
 	add_property_resource(object, "socket", id);
 
 	return SUCCESS;
@@ -513,7 +513,7 @@ PHP_METHOD(Redis, set)
     }
 
     val_free = redis_serialize(redis_sock, z_value, &val, &val_len TSRMLS_CC);
-	key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     if(expire > 0) {
             cmd_len = redis_cmd_format_static(&cmd, "SETEX", "sds", key, key_len, expire, val, val_len);
     } else {
@@ -552,7 +552,7 @@ PHP_METHOD(Redis, setex)
     }
 
     val_free = redis_serialize(redis_sock, z_value, &val, &val_len TSRMLS_CC);
-	key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "SETEX", "sds", key, key_len, expire, val, val_len);
     if(val_free) efree(val);
     if(key_free) efree(key);
@@ -587,7 +587,7 @@ PHP_METHOD(Redis, setnx)
     }
 
     val_free = redis_serialize(redis_sock, z_value, &val, &val_len TSRMLS_CC);
-	key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "SETNX", "ss", key, key_len, val, val_len);
     if(val_free) efree(val);
     if(key_free) efree(key);
@@ -625,7 +625,7 @@ PHP_METHOD(Redis, getSet)
     }
 
     val_free = redis_serialize(redis_sock, z_value, &val, &val_len TSRMLS_CC);
-	key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "GETSET", "ss", key, key_len, val, val_len);
     if(val_free) efree(val);
     if(key_free) efree(key);
@@ -690,8 +690,8 @@ PHP_METHOD(Redis, renameKey)
         RETURN_FALSE;
     }
 
-	int src_free = redis_key_prefix(redis_sock, &src, &src_len);
-	int dst_free = redis_key_prefix(redis_sock, &dst, &dst_len);
+	int src_free = redis_key_prefix(redis_sock, &src, &src_len TSRMLS_CC);
+	int dst_free = redis_key_prefix(redis_sock, &dst, &dst_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "RENAME", "ss", src, src_len, dst, dst_len);
     if(src_free) efree(src);
     if(dst_free) efree(dst);
@@ -726,8 +726,8 @@ PHP_METHOD(Redis, renameNx)
         RETURN_FALSE;
     }
 
-	int src_free = redis_key_prefix(redis_sock, &src, &src_len);
-	int dst_free = redis_key_prefix(redis_sock, &dst, &dst_len);
+	int src_free = redis_key_prefix(redis_sock, &src, &src_len TSRMLS_CC);
+	int dst_free = redis_key_prefix(redis_sock, &dst, &dst_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "RENAMENX", "ss", src, src_len, dst, dst_len);
     if(src_free) efree(src);
     if(dst_free) efree(dst);
@@ -760,7 +760,7 @@ PHP_METHOD(Redis, get)
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "GET", "s", key, key_len);
 	if(key_free) efree(key);
 
@@ -824,7 +824,7 @@ PHPAPI void redis_atomic_increment(INTERNAL_FUNCTION_PARAMETERS, char *keyword, 
     if (redis_sock_get(object, &redis_sock TSRMLS_CC) < 0) {
         RETURN_FALSE;
     }
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     if (val == 1) {
         cmd_len = redis_cmd_format_static(&cmd, keyword, "s", key, key_len);
     } else {
@@ -983,7 +983,7 @@ PHP_METHOD(Redis, getMultiple)
         if(*cmd) {
             old_cmd = cmd;
         }
-		int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+		int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
         cmd_len = redis_cmd_format(&cmd, "%s$%d" _NL "%s" _NL
                         , cmd, cmd_len
                         , key_len, key, key_len);
@@ -1034,7 +1034,7 @@ PHP_METHOD(Redis, exists)
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "EXISTS", "s", key, key_len);
 	if(key_free) efree(key);
 
@@ -1110,7 +1110,7 @@ PHP_METHOD(Redis, getKeys)
         RETURN_FALSE;
     }
 
-	int pattern_free = redis_key_prefix(redis_sock, &pattern, &pattern_len);
+	int pattern_free = redis_key_prefix(redis_sock, &pattern, &pattern_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "KEYS", "s", pattern, pattern_len);
 	if(pattern_free) efree(pattern);
 
@@ -1144,7 +1144,7 @@ PHP_METHOD(Redis, type)
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "TYPE", "s", key, key_len);
 	if(key_free) efree(key);
 
@@ -1174,7 +1174,7 @@ PHP_METHOD(Redis, append)
 		RETURN_FALSE;
 	}
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
 	cmd_len = redis_cmd_format_static(&cmd, "APPEND", "ss", key, key_len, val, val_len);
 	if(key_free) efree(key);
 
@@ -1203,7 +1203,7 @@ PHP_METHOD(Redis, getRange)
 		RETURN_FALSE;
 	}
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
 	cmd_len = redis_cmd_format_static(&cmd, "GETRANGE", "sdd", key, key_len, (int)start, (int)end);
 	if(key_free) efree(key);
 	REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len);
@@ -1231,7 +1231,7 @@ PHP_METHOD(Redis, setRange)
 		RETURN_FALSE;
 	}
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
 	cmd_len = redis_cmd_format_static(&cmd, "SETRANGE", "sds", key, key_len, (int)offset, val, val_len);
 	if(key_free) efree(key);
 	REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len);
@@ -1259,7 +1259,7 @@ PHP_METHOD(Redis, getBit)
 		RETURN_FALSE;
 	}
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
 	cmd_len = redis_cmd_format_static(&cmd, "GETBIT", "sd", key, key_len, (int)offset);
 	if(key_free) efree(key);
 	REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len);
@@ -1288,7 +1288,7 @@ PHP_METHOD(Redis, setBit)
 		RETURN_FALSE;
 	}
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
 	cmd_len = redis_cmd_format_static(&cmd, "SETBIT", "sdd", key, key_len, (int)offset, (int)val);
 	if(key_free) efree(key);
 	REDIS_PROCESS_REQUEST(redis_sock, cmd, cmd_len);
@@ -1317,7 +1317,7 @@ PHP_METHOD(Redis, strlen)
 		RETURN_FALSE;
 	}
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
 	cmd_len = redis_cmd_format_static(&cmd, "STRLEN", "s", key, key_len);
 	if(key_free) efree(key);
 
@@ -1348,7 +1348,7 @@ generic_push_function(INTERNAL_FUNCTION_PARAMETERS, char *keyword, int keyword_l
     }
 
     val_free = redis_serialize(redis_sock, z_value, &val, &val_len TSRMLS_CC);
-	key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, keyword, "ss", key, key_len, val, val_len);
     if(val_free) efree(val);
     if(key_free) efree(key);
@@ -1402,7 +1402,7 @@ PHP_METHOD(Redis, lInsert)
 	
 	if(strncasecmp(position, "after", 5) == 0 || strncasecmp(position, "before", 6) == 0) {
 
-		key_free = redis_key_prefix(redis_sock, &key, &key_len);
+		key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
         val_free = redis_serialize(redis_sock, z_value, &val, &val_len TSRMLS_CC);
         pivot_free = redis_serialize(redis_sock, z_pivot, &pivot, &pivot_len TSRMLS_CC);
         cmd_len = redis_cmd_format_static(&cmd, "LINSERT", "ssss", key, key_len, position, position_len, pivot, pivot_len, val, val_len);
@@ -1449,7 +1449,7 @@ generic_pop_function(INTERNAL_FUNCTION_PARAMETERS, char *keyword, int keyword_le
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, keyword, "s", key, key_len);
 	if(key_free) efree(key);
 
@@ -1537,7 +1537,7 @@ PHP_METHOD(Redis, lSize)
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "LLEN", "s", key, key_len);
 	if(key_free) efree(key);
 
@@ -1576,7 +1576,7 @@ PHP_METHOD(Redis, lRemove)
 
     /* LREM key count value */
     val_free = redis_serialize(redis_sock, z_value, &val, &val_len TSRMLS_CC);
-	key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "LREM", "sds", key, key_len, count, val, val_len);
     if(val_free) efree(val);
     if(key_free) efree(key);
@@ -1609,7 +1609,7 @@ PHP_METHOD(Redis, listTrim)
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "LTRIM", "sdd", key, key_len, (int)start, (int)end);
 	if(key_free) efree(key);
 
@@ -1643,7 +1643,7 @@ PHP_METHOD(Redis, lGet)
     }
 
     /* LINDEX key pos */
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "LINDEX", "sd", key, key_len, (int)index);
 	if(key_free) efree(key);
 
@@ -1676,7 +1676,7 @@ PHP_METHOD(Redis, lGetRange)
     }
 
     /* LRANGE key start end */
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "LRANGE", "sdd", key, key_len, (int)start, (int)end);
 	if(key_free) efree(key);
 
@@ -1711,7 +1711,7 @@ PHP_METHOD(Redis, sAdd)
     }
 
     val_free = redis_serialize(redis_sock, z_value, &val, &val_len TSRMLS_CC);
-	key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "SADD", "ss", key, key_len, val, val_len);
     if(val_free) efree(val);
     if(key_free) efree(key);
@@ -1743,7 +1743,7 @@ PHP_METHOD(Redis, sSize)
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "SCARD", "s", key, key_len);
 	if(key_free) efree(key);
 
@@ -1777,7 +1777,7 @@ PHP_METHOD(Redis, sRemove)
     }
 
     val_free = redis_serialize(redis_sock, z_value, &val, &val_len TSRMLS_CC);
-	key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "SREM", "ss", key, key_len, val, val_len);
     if(val_free) efree(val);
     if(key_free) efree(key);
@@ -1813,8 +1813,8 @@ PHP_METHOD(Redis, sMove)
     }
 
     val_free = redis_serialize(redis_sock, z_value, &val, &val_len TSRMLS_CC);
-	src_free = redis_key_prefix(redis_sock, &src, &src_len);
-	dst_free = redis_key_prefix(redis_sock, &dst, &dst_len);
+	src_free = redis_key_prefix(redis_sock, &src, &src_len TSRMLS_CC);
+	dst_free = redis_key_prefix(redis_sock, &dst, &dst_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "SMOVE", "sss", src, src_len, dst, dst_len, val, val_len);
     if(val_free) efree(val);
     if(src_free) efree(src);
@@ -1868,7 +1868,7 @@ PHP_METHOD(Redis, sContains)
     }
 
     val_free = redis_serialize(redis_sock, z_value, &val, &val_len TSRMLS_CC);
-	key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "SISMEMBER", "ss", key, key_len, val, val_len);
     if(val_free) efree(val);
     if(key_free) efree(key);
@@ -1900,7 +1900,7 @@ PHP_METHOD(Redis, sMembers)
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "SMEMBERS", "s", key, key_len);
 	if(key_free) efree(key);
 
@@ -2608,7 +2608,7 @@ PHPAPI void generic_expire_cmd(INTERNAL_FUNCTION_PARAMETERS, char *keyword, int 
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, keyword, "sd", key, key_len, t);
 	if(key_free) efree(key);
 
@@ -2658,7 +2658,7 @@ PHP_METHOD(Redis, lSet) {
     }
 
     val_free = redis_serialize(redis_sock, z_value, &val, &val_len TSRMLS_CC);
-	key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "LSET", "sds", key, key_len, index, val, val_len);
     if(val_free) efree(val);
     if(key_free) efree(key);
@@ -2824,7 +2824,7 @@ PHP_METHOD(Redis, persist) {
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "PERSIST", "s", key, key_len);
 	if(key_free) efree(key);
 
@@ -2855,7 +2855,7 @@ PHP_METHOD(Redis, ttl) {
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "TTL", "s", key, key_len);
 	if(key_free) efree(key);
 
@@ -2945,7 +2945,7 @@ PHP_METHOD(Redis, move) {
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "MOVE", "sd", key, key_len, dbNumber);
 	if(key_free) efree(key);
 
@@ -3011,7 +3011,7 @@ generic_mset(INTERNAL_FUNCTION_PARAMETERS, char *kw, void (*fun)(INTERNAL_FUNCTI
 
 
         int val_free = redis_serialize(redis_sock, *z_value_pp, &val, &val_len TSRMLS_CC);
-		int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+		int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
 
         if(key_len > 0) {
             key_len--;
@@ -3079,8 +3079,8 @@ PHP_METHOD(Redis, rpoplpush)
         RETURN_FALSE;
     }
 
-	int srckey_free = redis_key_prefix(redis_sock, &srckey, &srckey_len);
-	int dstkey_free = redis_key_prefix(redis_sock, &dstkey, &dstkey_len);
+	int srckey_free = redis_key_prefix(redis_sock, &srckey, &srckey_len TSRMLS_CC);
+	int dstkey_free = redis_key_prefix(redis_sock, &dstkey, &dstkey_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "RPOPLPUSH", "ss", srckey, srckey_len, dstkey, dstkey_len);
 	if(srckey_free) efree(srckey);
 	if(dstkey_free) efree(dstkey);
@@ -3116,7 +3116,7 @@ PHP_METHOD(Redis, zAdd) {
     }
 
     val_free = redis_serialize(redis_sock, z_value, &val, &val_len TSRMLS_CC);
-	key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "ZADD", "sfs", key, key_len, score, val, val_len);
     if(val_free) efree(val);
     if(key_free) efree(key);
@@ -3150,7 +3150,7 @@ PHP_METHOD(Redis, zRange)
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     if(withscores) {
         cmd_len = redis_cmd_format_static(&cmd, "ZRANGE", "sdds", key, key_len, start, end, "WITHSCORES", 10);
     } else {
@@ -3197,7 +3197,7 @@ PHP_METHOD(Redis, zDelete)
     }
 
     val_free = redis_serialize(redis_sock, z_value, &val, &val_len TSRMLS_CC);
-	key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "ZREM", "ss", key, key_len, val, val_len);
     if(val_free) efree(val);
     if(key_free) efree(key);
@@ -3232,7 +3232,7 @@ PHP_METHOD(Redis, zDeleteRangeByScore)
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "ZREMRANGEBYSCORE", "sss", key, key_len, start, start_len, end, end_len);
 	if(key_free) efree(key);
 
@@ -3265,7 +3265,7 @@ PHP_METHOD(Redis, zDeleteRangeByRank)
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "ZREMRANGEBYRANK", "sdd", key, key_len, (int)start, (int)end);
 	if(key_free) efree(key);
 
@@ -3299,7 +3299,7 @@ PHP_METHOD(Redis, zReverseRange)
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     if(withscores) {
         cmd_len = redis_cmd_format_static(&cmd, "ZREVRANGE", "sdds", key, key_len, start, end, "WITHSCORES", 10);
     } else {
@@ -3326,7 +3326,7 @@ PHP_METHOD(Redis, zReverseRange)
 /* }}} */
 
 PHPAPI void
-redis_generic_zrange_by_score(INTERNAL_FUNCTION_PARAMETERS, char *keyword TSRMLS_DC) {
+redis_generic_zrange_by_score(INTERNAL_FUNCTION_PARAMETERS, char *keyword) {
 
     zval *object, *z_options = NULL, **z_limit_val_pp = NULL, **z_withscores_val_pp = NULL;
 
@@ -3378,7 +3378,7 @@ redis_generic_zrange_by_score(INTERNAL_FUNCTION_PARAMETERS, char *keyword TSRMLS
         }
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     if(withscores) {
         if(has_limit) {
             cmd_len = redis_cmd_format_static(&cmd, keyword, "ssssdds",
@@ -3424,14 +3424,14 @@ redis_generic_zrange_by_score(INTERNAL_FUNCTION_PARAMETERS, char *keyword TSRMLS
  */
 PHP_METHOD(Redis, zRangeByScore)
 {
-	redis_generic_zrange_by_score(INTERNAL_FUNCTION_PARAM_PASSTHRU, "ZRANGEBYSCORE" TSRMLS_CC);
+	redis_generic_zrange_by_score(INTERNAL_FUNCTION_PARAM_PASSTHRU, "ZRANGEBYSCORE");
 }
 /* }}} */
 /* {{{ proto array Redis::zRevRangeByScore(string key, string start , string end [,array options = NULL])
  */
 PHP_METHOD(Redis, zRevRangeByScore)
 {
-	redis_generic_zrange_by_score(INTERNAL_FUNCTION_PARAM_PASSTHRU, "ZREVRANGEBYSCORE" TSRMLS_CC);
+	redis_generic_zrange_by_score(INTERNAL_FUNCTION_PARAM_PASSTHRU, "ZREVRANGEBYSCORE");
 }
 
 /* {{{ proto array Redis::zCount(string key, string start , string end)
@@ -3458,7 +3458,7 @@ PHP_METHOD(Redis, zCount)
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "ZCOUNT", "sss", key, key_len, start, start_len, end, end_len);
 	if(key_free) efree(key);
 
@@ -3489,7 +3489,7 @@ PHP_METHOD(Redis, zCard)
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "ZCARD", "s", key, key_len);
 	if(key_free) efree(key);
 
@@ -3524,7 +3524,7 @@ PHP_METHOD(Redis, zScore)
     }
 
     val_free = redis_serialize(redis_sock, z_value, &val, &val_len TSRMLS_CC);
-	key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "ZSCORE", "ss", key, key_len, val, val_len);
     if(val_free) efree(val);
     if(key_free) efree(key);
@@ -3557,7 +3557,7 @@ PHPAPI void generic_rank_method(INTERNAL_FUNCTION_PARAMETERS, char *keyword, int
     }
 
     val_free = redis_serialize(redis_sock, z_value, &val, &val_len TSRMLS_CC);
-	key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, keyword, "ss", key, key_len, val, val_len);
     if(val_free) efree(val);
     if(key_free) efree(key);
@@ -3607,7 +3607,7 @@ PHPAPI void generic_incrby_method(INTERNAL_FUNCTION_PARAMETERS, char *keyword, i
     }
 
     val_free = redis_serialize(redis_sock, z_value, &val, &val_len TSRMLS_CC);
-	key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, keyword, "sfs", key, key_len, add, val, val_len);
     if(val_free) efree(val);
     if(key_free) efree(key);
@@ -3668,7 +3668,7 @@ PHPAPI void generic_z_command(INTERNAL_FUNCTION_PARAMETERS, char *command, int c
 
 	}
 
-    int free_key_output = redis_key_prefix(redis_sock, &key_output, &key_output_len);
+    int free_key_output = redis_key_prefix(redis_sock, &key_output, &key_output_len TSRMLS_CC);
 	cmd_elements = 3;
 	cmd_len = redis_cmd_format(&cmd,
                     "$%d" _NL /* command_len */
@@ -3699,7 +3699,7 @@ PHPAPI void generic_z_command(INTERNAL_FUNCTION_PARAMETERS, char *command, int c
 			char *data_str = Z_STRVAL_PP(data);
 			int data_len = Z_STRLEN_PP(data);
 
-			int free_data = redis_key_prefix(redis_sock, &data_str, &data_len);
+			int free_data = redis_key_prefix(redis_sock, &data_str, &data_len TSRMLS_CC);
             cmd_len = redis_cmd_format(&cmd,
                             "%s" /* cmd */
                             "$%d" _NL
@@ -3814,7 +3814,7 @@ generic_hset(INTERNAL_FUNCTION_PARAMETERS, char *kw, void (*fun)(INTERNAL_FUNCTI
     }
 
     val_free = redis_serialize(redis_sock, z_value, &val, &val_len TSRMLS_CC);
-	key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, kw, "sss", key, key_len, member, member_len, val, val_len);
     if(val_free) efree(val);
     if(key_free) efree(key);
@@ -3856,7 +3856,7 @@ PHP_METHOD(Redis, hGet)
     if (redis_sock_get(object, &redis_sock TSRMLS_CC) < 0) {
         RETURN_FALSE;
     }
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "HGET", "ss", key, key_len, member, member_len);
 	if(key_free) efree(key);
 
@@ -3887,7 +3887,7 @@ PHP_METHOD(Redis, hLen)
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "HLEN", "s", key, key_len);
 	if(key_free) efree(key);
 
@@ -3919,7 +3919,7 @@ generic_hash_command_2(INTERNAL_FUNCTION_PARAMETERS, char *keyword, int keyword_
             ZVAL_BOOL(return_value, 0);
             return NULL;
     }
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, keyword, "ss", key, key_len, member, member_len);
 	if(key_free) efree(key);
 
@@ -3977,7 +3977,7 @@ generic_hash_command_1(INTERNAL_FUNCTION_PARAMETERS, char *keyword, int keyword_
             ZVAL_BOOL(return_value, 0);
             return NULL;
     }
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, keyword, "s", key, key_len);
 	if(key_free) efree(key);
 
@@ -4121,7 +4121,7 @@ PHP_METHOD(Redis, hIncrBy)
 
 
     /* HINCRBY key member amount */
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "HINCRBY", "sss", key, key_len, member, member_len, val, val_len);
 	if(key_free) efree(key);
 
@@ -4162,7 +4162,7 @@ PHP_METHOD(Redis, hMget) {
     for(i = 0; i < nb_fields; ++i) {
             z_keys[i] = NULL;
     }
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
 
     cmd_len = redis_cmd_format(&cmd,
                     "*%d" _NL
@@ -4247,7 +4247,7 @@ PHP_METHOD(Redis, hMset)
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format(&cmd, 
                     "$5" _NL "HMSET" _NL
                     "$%d" _NL "%s" _NL
@@ -4644,7 +4644,7 @@ PHP_METHOD(Redis, publish)
         RETURN_FALSE;
     }
 
-	int key_free = redis_key_prefix(redis_sock, &key, &key_len);
+	int key_free = redis_key_prefix(redis_sock, &key, &key_len TSRMLS_CC);
     cmd_len = redis_cmd_format_static(&cmd, "PUBLISH", "ss", key, key_len, val, val_len);
 	if(key_free) efree(key);
 


### PR DESCRIPTION
do not use add_constant_long, use zend_declare_class_constant*.. in recent PHP, it alloc a zval_gc_info for item, not zval..   this may cause segfault in some case..

then I fixed the ZTS build

thanks
